### PR TITLE
Start line numbering at 1 when acting on entire file

### DIFF
--- a/lib/act/helper.rb
+++ b/lib/act/helper.rb
@@ -50,7 +50,7 @@ module Act
     # @return [String]
     #
     def self.add_line_numbers(string, start_line, highlight_line = nil)
-      start_line ||= 0
+      start_line ||= 1
       line_count = start_line
       numbered_lines = string.lines.map do |line|
         number = line_count.to_s.ljust(3)


### PR DESCRIPTION
When acting on the entire file, line numbering should start at 1 for consistency with other programs and usage of act on partial files.

Here's an example of the bug (see line 7):

![screen shot 2014-04-04 at 2 44 18 pm](https://cloud.githubusercontent.com/assets/6197/2620669/54c5a908-bc42-11e3-9816-eeca6c4d15f9.png)
