### PR TITLE
Use rouge for syntax highlighting

### DIFF
--- a/act.gemspec
+++ b/act.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "claide", "~> 0.5"
   spec.add_runtime_dependency "colored", "~> 1.2"
+  spec.add_runtime_dependency "rouge", '~> 1.7'
   spec.add_runtime_dependency "activesupport"
 
   spec.add_development_dependency "bundler", "~> 1.5"

--- a/act.gemspec
+++ b/act.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Act::VERSION
   spec.authors       = ["Fabio Pelosin"]
   spec.email         = ["fabiopelosin@gmail.com"]
-  spec.summary       = %q{Act the command line tool to act on files.}
+  spec.summary       = %q{Act, the command line tool to act on files.}
   spec.homepage      = "https://github.com/irrationalfab/act"
   spec.license       = "MIT"
 

--- a/lib/act/command.rb
+++ b/lib/act/command.rb
@@ -130,10 +130,10 @@ module Act
     def cat_string(string, file = nil)
       if string
         path = file.path if file
-        @lexer ||= Helper.lexer(path)
+        @lexer ||= Helper.lexer(path, string)
         string = Helper.strip_indentation(string)
         string = Helper.prettify(string, @lexer) if @prettify
-        string = Helper.syntax_highlith(string, @lexer) if self.ansi_output?
+        string = Helper.syntax_highlight(string, @lexer) if self.ansi_output?
         string = Helper.add_line_numbers(string, file.from_line, file.highlight_line) if @number_lines && file
         UI.puts "\n#{string}"
       else

--- a/lib/act/command.rb
+++ b/lib/act/command.rb
@@ -15,7 +15,7 @@ module Act
 
     def self.arguments
       [
-        ['PATH', :optional],
+        CLAide::Argument.new('PATH', false),
       ]
     end
 

--- a/lib/act/command.rb
+++ b/lib/act/command.rb
@@ -23,6 +23,7 @@ module Act
       [
         ['--open', 'Open the file in $EDITOR instead of printing it'],
         ['--prettify', 'Prettify output'],
+        ['--always-color', 'Always color the output'],
         ['--line-numbers', 'Show output with line numbers'],
         ['--lexer=NAME', 'Use the given lexer'],
       ].concat(super)
@@ -41,6 +42,7 @@ module Act
       @prettify = argv.flag?('prettify', false)
       @number_lines = argv.flag?('line-numbers', false)
       @lexer = argv.option('lexer', false)
+      @always_color = argv.flag?('always-color')
       @file_string = argv.shift_argument
       super
     end
@@ -133,7 +135,7 @@ module Act
         @lexer ||= Helper.lexer(path, string)
         string = Helper.strip_indentation(string)
         string = Helper.prettify(string, @lexer) if @prettify
-        string = Helper.syntax_highlight(string, @lexer) if self.ansi_output?
+        string = Helper.syntax_highlight(string, @lexer) if ansi_output? || @always_color
         string = Helper.add_line_numbers(string, file.from_line, file.highlight_line) if @number_lines && file
         UI.puts "\n#{string}"
       else

--- a/lib/act/command.rb
+++ b/lib/act/command.rb
@@ -137,7 +137,7 @@ module Act
         string = Helper.prettify(string, @lexer) if @prettify
         string = Helper.syntax_highlight(string, @lexer) if ansi_output? || @always_color
         string = Helper.add_line_numbers(string, file.from_line, file.highlight_line) if @number_lines && file
-        UI.puts "\n#{string}"
+        UI.puts UI.tty? ? "\n#{string}" : string
       else
         UI.warn '[!] Nothing to show'
       end

--- a/lib/act/helper.rb
+++ b/lib/act/helper.rb
@@ -1,6 +1,7 @@
 require 'colored'
 require 'active_support/core_ext/string/strip'
 require 'open3'
+require 'rouge'
 
 module Act
   module Helper
@@ -92,21 +93,9 @@ module Act
 
     # @return [String]
     #
-    def self.syntax_highlith(string, lexer)
-      raise ArgumentError unless string
-      raise ArgumentError unless lexer
-      return string if `which pygmentize`.strip.empty?
-      result = nil
-      Open3.popen3("pygmentize -l #{lexer} -O encoding=utf8") do |stdin, stdout, stderr, wait_thr|
-        stdin.write(string)
-        stdin.close_write
-        result = stdout.read
-        unless wait_thr.value.success?
-          warn '[!] Syntax highlighting via the pygmentize tool failed'
-          result = string
-        end
-      end
-      result
+    def self.syntax_highlight(string, lexer)
+      formatter = Rouge::Formatters::Terminal256.new(:theme => 'monokai')
+      Rouge.highlight(string, lexer, formatter)
     end
 
   end

--- a/lib/act/helper.rb
+++ b/lib/act/helper.rb
@@ -64,18 +64,11 @@ module Act
       numbered_lines.join
     end
 
-    def self.lexer(file_name)
-      case file_name
-      when 'Gemfile', 'Rakefile', 'Podfile'
-        'rb'
-      when 'Podfile.lock', 'Gemfile.lock'
-        'yaml'
+    def self.lexer(file_name, string = nil)
+      if string
+        Rouge::Lexer.guess(:filename => file_name, :source => string).tag
       else
-        if file_name
-          `pygmentize -N #{file_name}`.chomp
-        else
-          'text'
-        end
+        Rouge::Lexer.guess_by_filename(file_name).tag
       end
     end
 

--- a/lib/act/user_interface.rb
+++ b/lib/act/user_interface.rb
@@ -9,6 +9,10 @@ module Act
     def self.warn(message)
       STDERR.puts message
     end
+
+    def self.tty?
+      STDOUT.tty?
+    end
   end
 
   UI = UserInterface

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -52,16 +52,23 @@ module Act
     #-------------------------------------------------------------------------#
 
     describe 'lexer' do
-      it 'infers the lexer according to the extension using pygmentize' do
+      it 'infers the lexer according to the extension' do
         file_name = 'test.rb'
         result = @subject.lexer(file_name)
-        result.should == 'rb'
+        result.should == 'ruby'
+      end
+
+      it 'infers the lexer according to the text' do
+        file_name = 'rm'
+        text = "#!/usr/bin/ruby\n\nrequire 'set'\nputs 'hello'\n3.tap { p 3 }"
+        result = @subject.lexer(file_name, text)
+        result.should == 'ruby'
       end
 
       it 'infers the lexer according to the file name' do
         file_name = 'Gemfile'
         result = @subject.lexer(file_name)
-        result.should == 'rb'
+        result.should == 'ruby'
       end
     end
 


### PR DESCRIPTION
This gets rid of the python/pygments dependency.

Closes https://github.com/fabiopelosin/act/issues/8.
